### PR TITLE
Change Keys to allow number input in text boxes

### DIFF
--- a/src/palesnipe.js
+++ b/src/palesnipe.js
@@ -70,4 +70,4 @@
 
     $("nav.view-tab-bar").append('<button class="view-tab-bar-item" style="order: 6"><a style="text-decoration:none;color:inherit" target="paletools" href="http://eallegretta.github.io/paletools.html">Palesnipe ' + ver + '</a>');
     window.__palesnipe = true;
-})(37,39,40,38,188,189,32,17,18);
+})(37,39,40,38,188,190,32,222,187);

--- a/src/palesnipe.js
+++ b/src/palesnipe.js
@@ -70,4 +70,4 @@
 
     $("nav.view-tab-bar").append('<button class="view-tab-bar-item" style="order: 6"><a style="text-decoration:none;color:inherit" target="paletools" href="http://eallegretta.github.io/paletools.html">Palesnipe ' + ver + '</a>');
     window.__palesnipe = true;
-})(37,39,40,38,49,50,51,52,53);
+})(37,39,40,38,188,189,32,17,18);


### PR DESCRIPTION
Suggestion to change the mapped keys used for the actions from 1-5 to ',', '.', ' ', 'Ctrl' & 'Alt', in order to be able to input numbers in the text boxes when searching. 

Suggested mapping as follows, based on standard spanish keyboard:

, (comma) -> backButtonKey
. (dot) -> searchButtonKey
 (space) -> buyNowButtonKey
' (aspostrophe) -> sendToTransferListButtonKey
¡ (open exclamation mark) -> sendToClubButtonKey