### PR TITLE
Keep buy now values after comparing prices for quicker listings

### DIFF
--- a/src/paletools/src/services/transferMarket.js
+++ b/src/paletools/src/services/transferMarket.js
@@ -148,7 +148,7 @@ async function getPriceLimits(item) {
 	});
 }
 
-function getSellBidPrice(bin) {
+export function getSellBidPrice(bin) {
 	if (bin <= 1000) return bin - 50;
 	if (bin > 1000 && bin <= 10000) return bin - 100;
 	if (bin > 10000 && bin <= 50000) return bin - 250;


### PR DESCRIPTION
Con este cambio se mantiene el monto mínimo de `Buy Now` de cada jugador en un array, y cuando se intenta listar el jugador en el mercado se coloca inmediatamente ese valor, así el usuario no necesita volverlo a escribir o recordarlo.

Esto me ha servido mucho con la venta de bronzes, el `Buy Now` default es de 5,100 monedas, pero la mayoría están listados en 200 monedas, yo comparo un jugador, veo que se vende por 200 monedas, hago click en listar y voilá, el valor ya está seleccionado automágicamente.