### PR TITLE
Display League in the Player Card Info

### DIFF
--- a/src/paletools/src/localization/index.js
+++ b/src/paletools/src/localization/index.js
@@ -1,5 +1,6 @@
 import localeEn from './locales/en';
 import localeEs from "./locales/es";
+import getWindow from "../services/window";
 
 const dictionary = {
     'en': localeEn,
@@ -34,4 +35,8 @@ const monthKeys = ["january", "february", "march", "april", "june", "july", "aug
 
 export function localizeMonthAbbr(date) {
     return localize(`date.${monthKeys[date.getMonth() - 1]}`);
+}
+
+export function getLeagueAbbr5(id) {
+    return localize(`global.leagueabbr5.${getWindow().APP_YEAR}.league${id}`);
 }

--- a/src/paletools/src/localization/locales/en.js
+++ b/src/paletools/src/localization/locales/en.js
@@ -234,6 +234,7 @@ export default {
     "plugins.playerCardInfo.settings.untradeable": "Display untradeable icon",
     "plugins.playerCardInfo.settings.pristine": "Display if a card is pristine (7 contracts, 1 owner) only on search results",
     "plugins.playerCardInfo.settings.contracts": "Display contracts",
+    "plugins.playerCardInfo.settings.league": "Display League",
     /// #endif
 
     /// #if process.env.TRACK_TRANSACTIONS

--- a/src/paletools/src/localization/locales/es.js
+++ b/src/paletools/src/localization/locales/es.js
@@ -230,6 +230,7 @@ export default {
     "plugins.playerCardInfo.settings.untradeable": "Mostrar si es intransferible",
     "plugins.playerCardInfo.settings.pristine": "Mostrar si es pristino (7 contratos, 1 dueño), solo en resultados de búsqueda",
     "plugins.playerCardInfo.settings.contracts": "Mostrar contratos",
+    "plugins.playerCardInfo.settings.league": "Mostrar Liga",
     /// #endif
 
     /// #if process.env.TRACK_TRANSACTIONS

--- a/src/paletools/src/plugins/playerCardInfo/index.js
+++ b/src/paletools/src/plugins/playerCardInfo/index.js
@@ -7,7 +7,7 @@ import settings, { saveConfiguration } from "../../settings";
 import { addClass, append, createElem } from "../../utils/dom";
 import { hide, show } from "../../utils/visibility";
 import { addStyle, removeStyle } from "../../utils/styles";
-import localize, { localizePosition } from "../../localization";
+import localize, { localizePosition, getLeagueAbbr5 } from "../../localization";
 
 const cfg = settings.plugins.playerCardInfo;
 
@@ -26,6 +26,7 @@ function run() {
         const result = UTPlayerItemView_renderItem.call(this, player, t);
         if (settings.enabled && cfg.enabled) {
             const starsContainer = createElem("div", { className: "stars" });
+            const leagueContainer = createElem("div", { className: "league" });
 
             const colors = t.getExpColorMap(player.getTier()).header;
             const colorStyle = `color: rgba(${colors.r},${colors.g},${colors.b},1)`;
@@ -58,6 +59,12 @@ function run() {
                 this.__loanInfoTab.textContent = player.contract;
             }
 
+            if (cfg.league) {
+                leagueContainer.textContent = getLeagueAbbr5(player.leagueId);;
+                addClass(leagueContainer, `league-${player.leagueId}`);
+                append(this.__mainViewDiv, leagueContainer);
+            }
+
             const altPosContainer = createElem("div", { className: "alternative-positions" });
             if (cfg.alternatePositions) {
                 for (let position of player.possiblePositions || []) {
@@ -70,8 +77,8 @@ function run() {
                 append(this.__mainViewDiv, altPosContainer);
             }
 
-            on(EVENTS.APP_ENABLED, () => { show(altPosContainer); show(starsContainer); show(untradeableContainer); addStyles(); });
-            on(EVENTS.APP_DISABLED, () => { hide(altPosContainer); hide(starsContainer); hide(untradeableContainer); removeStyles(); });
+            on(EVENTS.APP_ENABLED, () => { show(altPosContainer); show(starsContainer); show(untradeableContainer); show(leagueContainer);addStyles(); });
+            on(EVENTS.APP_DISABLED, () => { hide(altPosContainer); hide(starsContainer); hide(untradeableContainer); hide(leagueContainer); removeStyles(); });
         }
 
         return result;
@@ -82,7 +89,7 @@ function run() {
 
 function menu() {
     const container = document.createElement("div");
-    ["enabled", "alternatePositions", "skillMoves", "weakFoot", "untradeable", "pristine", "contracts"].forEach(x => {
+    ["enabled", "alternatePositions", "skillMoves", "weakFoot", "untradeable", "pristine", "contracts", "league"].forEach(x => {
         addLabelWithToggle(container, x === "enabled" ? x : `plugins.playerCardInfo.settings.${x}`, cfg[x], toggleState => {
             cfg[x] = toggleState;
             saveConfiguration();

--- a/src/paletools/src/plugins/playerCardInfo/styles.css
+++ b/src/paletools/src/plugins/playerCardInfo/styles.css
@@ -126,3 +126,45 @@
     color: #0099CC;
     border: 1px solid #0099CC;
 }
+
+.league {
+    font-size: 10px;
+    font-family: 'UltimateTeamCondensed';
+    display: inline-block;
+    position: absolute;
+    top: 4px;
+    left: 35px;
+    border-radius: 25%;
+    width: 27px;
+    text-align: center;
+    height: 16px;
+    line-height: 16px;
+    margin-bottom: 1px;
+    background-color: white;
+    color: #0099CC;
+    border: 1px solid #0099CC
+}
+
+.large .league {
+    top: -128px;
+    left: 60px;
+}
+
+.league-13,
+.league-14,
+.league-16,
+.league-31,
+.league-19,
+.league-53,
+.league-4,
+.league-2012,
+.league-10,
+.league-1003,
+.league-39,
+.league-350,
+.league-1014,
+.league-68 {
+    background-color: #0099cc;
+    color: white;
+    border: 1px solid white;
+}

--- a/src/paletools/src/settings.js
+++ b/src/paletools/src/settings.js
@@ -173,7 +173,8 @@ let settings = {
             weakFoot: true,
             untradeable: true,
             pristine: true,
-            contracts: true
+            contracts: true,
+            league: true
         },
         transactionsHistory: {
             enabled: true


### PR DESCRIPTION
With the newly added League SBC's it's is very important to know first hand if a player belongs to a league that is potentially profitable.
Or when you are crafting Winter Upgrade SBC's is nice to immediately know if a card can be thrown into the upgrade SBC if the league is not included on the Winter League SBC's